### PR TITLE
Removed feed id from locator.view_station

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ Make sure your vagrant is running if you haven't already by using `vagrant up`
 
 Then ssh into the vagrant box by using `vagrant ssh`
 
-Start the dev server by using: `python manage.py runserver 10.0.2.15:8000`
+Start the dev server by using: `python manage.py runserver 0:8000`
 
 On your host system you should be able to use http://127.0.0.1:8000/ to access bluebell

--- a/bluebell/consumer/views/locator.py
+++ b/bluebell/consumer/views/locator.py
@@ -293,10 +293,7 @@ def view_station(request,station_id):
         children_feeds = callsign_obj.related('children')
 
         for feed in children_feeds.items():
-            feed_url = feed.self
-            feed_id = feed_url[feed_url.rfind('/')+1:-5]
             feed_obj = {}
-            feed_obj['id'] = feed_id
             # over the air channel
             # aka subchannel
             ota_channel = feed.related('summary').content

--- a/dev/vagrant-provision.sh
+++ b/dev/vagrant-provision.sh
@@ -17,6 +17,10 @@ fi
 #sudo yum -y install memcached
 #
 # Run a bunch of commands as the user
+
+# update TSL to be able to use pip
+sudo yum install openssl libssl-dev
+
 echo "===> Running scripts"
 su $1 << 'SCRIPT'
 ls ~


### PR DESCRIPTION
Feed id is not used anywhere in the template anyway.
Updated vagrant provisioning to update TSL to be able to install requirements via pip